### PR TITLE
Version 0.1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 install:
   - pwd
   - pip install .

--- a/postmancli/metadata.py
+++ b/postmancli/metadata.py
@@ -3,7 +3,7 @@
 
 class Metadata:
     def __init__(self):
-        self.__version__ = '0.1.1'
+        self.__version__ = '0.1.2'
         self.__author__ = 'Rubén de Celis Hernández'
 
     def get_version(self):

--- a/postmancli/sendemail.py
+++ b/postmancli/sendemail.py
@@ -9,6 +9,7 @@ from email import encoders
 import os
 import time
 import random
+import sys
 
 
 def generate_message_id(msg_from):
@@ -44,7 +45,11 @@ def send_mail(server, msg_from, msg_to, subject, text, files=[], debug=False):
         msg.attach(part)
 
     if not debug:
-        smtp = smtplib.SMTP_SSL()
+        # https://bugs.python.org/issue36094
+        if sys.version_info >= (3, 7):
+            smtp = smtplib.SMTP_SSL(server['host'])
+        else:
+            smtp = smtplib.SMTP_SSL()
         smtp.connect(server['host'], server['port'])
         try:
             smtp.login(server['user'], server['password'])

--- a/setup.py
+++ b/setup.py
@@ -41,5 +41,6 @@ setup(
                  'Programming Language :: Python :: 3.5',
                  'Programming Language :: Python :: 3.6',
                  'Programming Language :: Python :: 3.7',
-                 'Programming Language :: Python :: 3.8'],
+                 'Programming Language :: Python :: 3.8',
+                 'Programming Language :: Python :: 3.9'],
 )


### PR DESCRIPTION
# Add support for Python 3.9 in TravisCI

- https://github.com/RDCH106/postman-cli/commit/7922b58e5d28b21acc2d9ee6ccccb98f63c41e38

# Add workaround for 🐛 issue36094

**Error**:

`ValueError: server_hostname cannot be an empty string or start with a leading dot.`

**Affected**:
- SMTP
- SMTP_SSL

🐍 https://bugs.python.org/issue36094

🤓 https://stackoverflow.com/a/53385409/9739532

