### PR TITLE
Version 0.2.0

### DIFF
--- a/postmancli/core.py
+++ b/postmancli/core.py
@@ -27,7 +27,8 @@ class Postman(object):
 
     def run(self):
         server_values = Validator.get_server_values(self.args.server)
-        server_values[0] = server_values[0] + '@' + Validator.get_main_domain(server_values[2])
+        if len(server_values[0].split("@")) == 1:
+            server_values[0] = server_values[0] + '@' + Validator.get_main_domain(server_values[2])
         send_mail({'user': server_values[0], 'password': server_values[1],
                    'host': server_values[2], 'port': int(server_values[3])},
                   msg_from=self.args.msg_from, msg_to=self.args.msg_to, subject=self.args.subject, text=self.args.text,

--- a/postmancli/metadata.py
+++ b/postmancli/metadata.py
@@ -3,7 +3,7 @@
 
 class Metadata:
     def __init__(self):
-        self.__version__ = '0.1.2'
+        self.__version__ = '0.2.0'
         self.__author__ = 'Rubén de Celis Hernández'
 
     def get_version(self):

--- a/postmancli/validation.py
+++ b/postmancli/validation.py
@@ -7,7 +7,7 @@ import argparse
 class Validator(object):
     __domain_pattern = re.compile("^([a-z0-9]+(\-[a-z0-9]+)*\.)+[a-z]{2,3}$")
     __main_domain_pattern = re.compile("([a-z0-9]+(\-[a-z0-9]+)*\.){1}[a-z]{2,3}$")
-    __server_pattern = re.compile("^([\w\.]+){1}:([\w\.]+){1}@([\w\-\.]+){1}:(\d+){1}$")
+    __server_pattern = re.compile("^([\w\.@\-]+){1}:([\w\.]+){1}@([\w\-\.]+){1}:(\d+){1}$")
 
     @staticmethod
     def check_domain(string):
@@ -20,8 +20,12 @@ class Validator(object):
     def check_server(string):
         ret = Validator.__server_pattern.match(string)
         if ret:
-            tmp_val = string.split("@")
+            reverse_string = string[::-1]
+            tmp_val = reverse_string.split("@", 1)
             if len(tmp_val) == 2:
+                tmp_swap = tmp_val[0]
+                tmp_val[0] = tmp_val[1][::-1]
+                tmp_val[1] = tmp_swap[::-1]
                 tmp_val = tmp_val[1].split(":")
                 if len(tmp_val) == 2:
                     if Validator.check_domain(tmp_val[0]):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -50,6 +50,8 @@ class TestClassValidations(unittest.TestCase):
     def test_server(self):
         self.assertEqual('user:password@domain.com:443',
                          Validator.check_server('user:password@domain.com:443'))
+        self.assertEqual('user@domain.com:password@domain.com:443',
+                         Validator.check_server('user@domain.com:password@domain.com:443'))
         self.assertEqual('user:password@subdomain.domain.com:443',
                          Validator.check_server('user:password@subdomain.domain.com:443'))
         self.assertEqual('user:password@more-domain.com:443',
@@ -68,6 +70,9 @@ class TestClassValidations(unittest.TestCase):
                          Validator.check_server('user.1:password.1@subdomain.more-domain.com:443'))
         self.assertEqual('user.1:password.1@more-subdomain.more-domain.com:443',
                          Validator.check_server('user.1:password.1@more-subdomain.more-domain.com:443'))
+        self.assertEqual('user.1@more-subdomain.more-domain.com:password.1@more-subdomain.more-domain.com:443',
+                         Validator.check_server('user.1@more-subdomain.more-domain.com:password.1'
+                                                '@more-subdomain.more-domain.com:443'))
         try:
             Validator.check_server('domain.com:443')
             self.fail('Exception not raised')


### PR DESCRIPTION
# Add full email support as a user identification

Now it is possible to use format like `user@email_domain.com` for server `argument` as identification

**Example:**

```
$ postmancli -S user@email_domain.com:password@smtp.gmail.com:465 -f user@gmail.com -t someone@gmail.com -s postman-cli --text "Hello everyone!@nl@@tab@It seems that this works ..." -a "file.txt" "photo.jpg"
```